### PR TITLE
Add hierarchical .gito/config.toml support

### DIFF
--- a/gito/pipeline.py
+++ b/gito/pipeline.py
@@ -2,6 +2,7 @@ import logging
 import warnings
 from enum import StrEnum
 from dataclasses import dataclass, field
+from pathlib import PurePosixPath
 
 from microcore import ui
 from microcore.utils import resolve_callable
@@ -43,6 +44,12 @@ class PipelineStep:
     call: str
     envs: list[PipelineEnv] = field(default_factory=PipelineEnv.all)
     enabled: bool = field(default=True)
+    scope: str = field(default="")
+    """
+    Repo-relative directory the step applies to (POSIX path, no leading slash,
+    no trailing slash). Empty string means repo-wide. Set automatically when a
+    step is defined in a sub-directory's .gito/config.toml.
+    """
 
     def get_callable(self):
         """
@@ -52,6 +59,18 @@ class PipelineStep:
 
     def run(self, *args, **kwargs):
         return self.get_callable()(*args, **kwargs)
+
+    def matches_path(self, path: str) -> bool:
+        """True if `path` falls under this step's scope."""
+        if not self.scope:
+            return True
+        p = PurePosixPath(path)
+        scope = PurePosixPath(self.scope)
+        try:
+            p.relative_to(scope)
+            return True
+        except ValueError:
+            return False
 
 
 @dataclass
@@ -64,29 +83,49 @@ class Pipeline:
     def enabled_steps(self):
         return {k: v for k, v in self.steps.items() if v.enabled}
 
+    def _scoped_ctx_kwargs(self, step: PipelineStep) -> dict:
+        """
+        Build kwargs from ctx, filtering `diff` to files under step.scope.
+        Returns the filtered diff list (possibly empty) so callers can decide
+        whether to skip the step.
+        """
+        ctx_kwargs = vars(self.ctx).copy()
+        if step.scope and self.ctx.diff is not None:
+            ctx_kwargs["diff"] = [
+                f for f in self.ctx.diff if step.matches_path(f.path)
+            ]
+        return ctx_kwargs
+
     def run(self, *args, **kwargs):
         cur_env = PipelineEnv.current()
         logging.info("Running pipeline... [env: %s]", ui.yellow(cur_env))
         for step_name, step in self.enabled_steps.items():
-            if cur_env in step.envs:
-                logging.info(f"Running pipeline step: {step_name}")
-                try:
-                    step_output = step.run(*args, **kwargs, **vars(self.ctx))
-                    if isinstance(step_output, dict):
-                        self.ctx.pipeline_out.update(step_output)
-                    self.ctx.pipeline_out[step_name] = step_output
-                    if self.verbose and step_output:
-                        logging.info(f"Pipeline step {step_name} output: {repr(step_output)}")
-                    if not step_output:
-                        logging.warning(
-                            f'Pipeline step "{step_name}" '
-                            f"returned no result ({repr(step_output)})."
-                        )
-                except Exception as e:
-                    logging.error(f'Error in pipeline step "{step_name}": {e}')
-            else:
+            if cur_env not in step.envs:
                 logging.info(
                     f"Skipping pipeline step: {step_name}"
                     f" [env: {ui.yellow(cur_env)} not in {step.envs}]"
                 )
+                continue
+            ctx_kwargs = self._scoped_ctx_kwargs(step)
+            if step.scope and not ctx_kwargs.get("diff"):
+                logging.info(
+                    f"Skipping pipeline step: {step_name}"
+                    f" [scope {ui.yellow(step.scope)} has no matching files in diff]"
+                )
+                continue
+            logging.info(f"Running pipeline step: {step_name}")
+            try:
+                step_output = step.run(*args, **kwargs, **ctx_kwargs)
+                if isinstance(step_output, dict):
+                    self.ctx.pipeline_out.update(step_output)
+                self.ctx.pipeline_out[step_name] = step_output
+                if self.verbose and step_output:
+                    logging.info(f"Pipeline step {step_name} output: {repr(step_output)}")
+                if not step_output:
+                    logging.warning(
+                        f'Pipeline step "{step_name}" '
+                        f"returned no result ({repr(step_output)})."
+                    )
+            except Exception as e:
+                logging.error(f'Error in pipeline step "{step_name}": {e}')
         return self.ctx.pipeline_out

--- a/gito/project_config.py
+++ b/gito/project_config.py
@@ -1,15 +1,34 @@
 import logging
+import os
 import tomllib
-from dataclasses import dataclass, field
-from pathlib import Path
+from dataclasses import dataclass, field, fields
+from pathlib import Path, PurePosixPath
 
 import microcore as mc
 from microcore import ui
 from git import Repo
 
-from .constants import PROJECT_CONFIG_BUNDLED_DEFAULTS_FILE, PROJECT_CONFIG_FILE_PATH
+from .constants import (
+    PROJECT_CONFIG_BUNDLED_DEFAULTS_FILE,
+    PROJECT_CONFIG_FILE_NAME,
+    PROJECT_CONFIG_FILE_PATH,
+    PROJECT_GITO_FOLDER,
+)
 from .pipeline import PipelineStep
 from .utils.git_platform.github import detect_github_env
+
+
+# Fields that should be concatenated (cumulative) across hierarchy levels,
+# de-duplicated while preserving root-first order.
+_LIST_MERGE_FIELDS = frozenset({"aux_files", "exclude_files", "mention_triggers"})
+
+# Directories to skip when walking the repo for nested .gito/config.toml files.
+_DISCOVERY_SKIP_DIRS = frozenset({
+    ".git", ".hg", ".svn",
+    "node_modules", ".venv", "venv", "__pycache__",
+    ".tox", ".mypy_cache", ".pytest_cache", ".ruff_cache",
+    "dist", "build", ".idea", ".vscode",
+})
 
 
 @dataclass
@@ -66,48 +85,156 @@ class ProjectConfig:
         return config
 
     @staticmethod
-    def load_for_repo(repo: Repo) -> "ProjectConfig":
-        if repo.working_tree_dir is not None:
-            config_path = Path(repo.working_tree_dir) / PROJECT_CONFIG_FILE_PATH
-        else:
-            config_path = None
-        return ProjectConfig.load(config_path)
+    def _read_toml(path: Path) -> dict:
+        with open(path, "rb") as f:
+            return tomllib.load(f)
 
     @staticmethod
-    def load(config_path: str | Path | None = None) -> "ProjectConfig":
+    def _discover_subdir_configs(repo_root: Path) -> list[tuple[str, dict]]:
         """
-        Load the project configuration from the specified path.
-        If no path is provided, it defaults to the standard project config file path
-        (<current_project>/.gito/config.toml).
-        If the file exists, it merges the project-specific
-        configuration with the bundled defaults.
-        If not found, it uses only the defaults.
-        Args:
-            config_path (str | Path | None): Alternative path to the project configuration file.
+        Find every <subdir>/.gito/config.toml under `repo_root`, excluding the
+        root-level .gito/config.toml itself.
+
         Returns:
-            ProjectConfig: The loaded project configuration instance.
+            List of (scope, parsed_config_dict) where `scope` is the
+            POSIX-style relative directory of the config file (i.e. the
+            directory containing .gito/), e.g. "frontend" or "src/foo".
+            Sorted by scope depth ascending, then lexicographically — so the
+            shallowest config is applied first and deeper configs override it,
+            with the root config (applied last by the caller) winning overall.
         """
-        config = ProjectConfig._read_bundled_defaults()
+        results: list[tuple[str, dict]] = []
+        repo_root = repo_root.resolve()
+        for dirpath, dirnames, filenames in os.walk(repo_root):
+            # Prune ignored dirs in place so os.walk doesn't descend into them.
+            dirnames[:] = [d for d in dirnames if d not in _DISCOVERY_SKIP_DIRS]
+            if PROJECT_GITO_FOLDER not in dirnames:
+                continue
+            cfg_path = Path(dirpath) / PROJECT_GITO_FOLDER / PROJECT_CONFIG_FILE_NAME
+            if not cfg_path.is_file():
+                continue
+            scope_dir = Path(dirpath).relative_to(repo_root)
+            scope = PurePosixPath(*scope_dir.parts).as_posix() if scope_dir.parts else ""
+            if scope == "":
+                # Root-level .gito/config.toml is handled by the caller.
+                continue
+            try:
+                results.append((scope, ProjectConfig._read_toml(cfg_path)))
+            except Exception as e:
+                logging.warning(
+                    f"Failed to parse nested config {mc.utils.file_link(cfg_path)}: {e}"
+                )
+        results.sort(key=lambda item: (item[0].count("/"), item[0]))
+        return results
+
+    @staticmethod
+    def _merge_level(base: dict, overlay: dict, *, scope: str = "") -> dict:
+        """
+        Merge `overlay` into `base` in place; overlay wins on every conflict.
+        Apply levels in order `defaults -> subdirs -> root` to get "root
+        supersedes on conflicts".
+
+        - List fields in `_LIST_MERGE_FIELDS` concatenate (dedupe, base-first).
+        - `prompt_vars`: union of keys, overlay wins on conflict.
+        - `pipeline_steps`: union of step names; per-step dicts are field-merged
+          (overlay fields win, base fields fill gaps), preserving the original
+          single-file behavior where `enabled=false` in a project config only
+          flips that field and inherits `call` etc. from defaults.
+        - Pipeline step entries coming in via `overlay` get their `scope`
+          field set to the provided `scope` unless explicitly set in TOML.
+        - All other (scalar) fields: overlay overwrites.
+        """
+        for key, value in overlay.items():
+            if key in _LIST_MERGE_FIELDS:
+                merged = list(base.get(key, []))
+                for item in value or []:
+                    if item not in merged:
+                        merged.append(item)
+                base[key] = merged
+                continue
+
+            if key == "prompt_vars":
+                merged_vars = dict(base.get("prompt_vars", {}))
+                merged_vars.update(value or {})
+                base["prompt_vars"] = merged_vars
+                continue
+
+            if key == "pipeline_steps":
+                merged_steps = dict(base.get("pipeline_steps", {}))
+                for step_name, step_def in (value or {}).items():
+                    if isinstance(step_def, dict):
+                        step_def = dict(step_def)
+                        step_def.setdefault("scope", scope)
+                    existing = merged_steps.get(step_name)
+                    if isinstance(existing, dict) and isinstance(step_def, dict):
+                        merged_steps[step_name] = {**existing, **step_def}
+                    else:
+                        merged_steps[step_name] = step_def
+                base["pipeline_steps"] = merged_steps
+                continue
+
+            base[key] = value
+        return base
+
+    @staticmethod
+    def load_for_repo(repo: Repo) -> "ProjectConfig":
+        if repo.working_tree_dir is not None:
+            repo_root = Path(repo.working_tree_dir)
+            config_path = repo_root / PROJECT_CONFIG_FILE_PATH
+            return ProjectConfig.load(config_path, repo_root=repo_root)
+        return ProjectConfig.load(None)
+
+    @staticmethod
+    def load(
+        config_path: str | Path | None = None,
+        repo_root: str | Path | None = None,
+    ) -> "ProjectConfig":
+        """
+        Load the project configuration.
+
+        Merge order (each level only contributes keys it explicitly wrote):
+            bundled_defaults  -> nested <subdir>/.gito/config.toml files
+                              -> root .gito/config.toml (wins on conflict)
+
+        Cumulative rules:
+        - `aux_files`, `exclude_files`, `mention_triggers`: concatenated +
+          deduped across all levels.
+        - `prompt_vars`: union of keys; root wins on key conflict.
+        - `pipeline_steps`: union of step names; root wins on name conflict.
+          Steps defined in a sub-directory get `scope` set to that directory,
+          so they only apply to files under it.
+        - All other scalar fields: root overrides; sub-directory configs only
+          fill values the root did not explicitly set.
+
+        If `repo_root` is provided, sub-directory configs are discovered under
+        it. Otherwise discovery is skipped (back-compat with the single-file
+        load() API used in tests).
+        """
+        merged: dict = ProjectConfig._read_bundled_defaults()
         github_env = detect_github_env()
-        config["prompt_vars"] |= github_env | dict(github_env=github_env)
+        merged["prompt_vars"] |= github_env | dict(github_env=github_env)
 
         config_path = Path(config_path or PROJECT_CONFIG_FILE_PATH)
+        if repo_root is not None:
+            repo_root = Path(repo_root)
+            for scope, sub_cfg in ProjectConfig._discover_subdir_configs(repo_root):
+                logging.info(
+                    f"Loading sub-directory config "
+                    f"[{ui.cyan(scope)}/{PROJECT_GITO_FOLDER}/{PROJECT_CONFIG_FILE_NAME}]"
+                )
+                ProjectConfig._merge_level(merged, sub_cfg, scope=scope)
+
         if config_path.exists():
             logging.info(
                 f"Loading project-specific configuration from {mc.utils.file_link(config_path)}..."
             )
-            default_prompt_vars = config["prompt_vars"]
-            default_pipeline_steps = config["pipeline_steps"]
-            with open(config_path, "rb") as f:
-                config.update(tomllib.load(f))
-            # overriding prompt_vars config section will not empty default values
-            config["prompt_vars"] = default_prompt_vars | config["prompt_vars"]
-            # merge individual pipeline steps
-            for k, v in config["pipeline_steps"].items():
-                config["pipeline_steps"][k] = default_pipeline_steps.get(k, {}) | v
-            # merge pipeline steps dict
-            config["pipeline_steps"] = default_pipeline_steps | config["pipeline_steps"]
+            root_cfg = ProjectConfig._read_toml(config_path)
+            ProjectConfig._merge_level(merged, root_cfg, scope="")
         else:
             logging.info(f"No project config found at {ui.blue(config_path)}, using defaults")
 
-        return ProjectConfig(**config)
+        # Drop any keys that aren't dataclass fields (forward-compat with TOML
+        # users who add unknown options).
+        known = {f.name for f in fields(ProjectConfig)}
+        merged = {k: v for k, v in merged.items() if k in known}
+        return ProjectConfig(**merged)

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -117,3 +117,64 @@ def test_get_callable():
         call="gito.pipeline_steps.jira.fetch_associated_issue"
     ).get_callable()
     assert callable(callable_fn), "Expected a callable function"
+
+
+def test_pipeline_step_scope_matches_path():
+    repo_wide = PipelineStep(call="x")
+    scoped = PipelineStep(call="x", scope="frontend")
+    assert repo_wide.matches_path("anything/here.py")
+    assert scoped.matches_path("frontend/app.tsx")
+    assert scoped.matches_path("frontend/sub/dir/x.ts")
+    assert not scoped.matches_path("backend/app.py")
+    # Prefix-only match must respect path boundaries.
+    assert not scoped.matches_path("frontend2/app.tsx")
+
+
+def test_pipeline_run_filters_diff_by_scope(monkeypatch, patch_github_action_env):
+    """A scoped step only sees diff entries under its scope."""
+    mc.configure(LLM_API_TYPE=mc.ApiType.NONE)
+    patch_github_action_env(False)
+
+    class _F:
+        def __init__(self, path):
+            self.path = path
+
+    diff = [_F("frontend/a.tsx"), _F("backend/b.py")]
+    seen = {}
+
+    def _fake_step_run(*args, **kwargs):
+        seen["diff"] = list(kwargs.get("diff") or [])
+        return {"ran": True}
+
+    step = PipelineStep(call="x", envs=[PipelineEnv.LOCAL], scope="frontend")
+    step.run = _fake_step_run
+
+    ctx = Context(report=Report(), config=ProjectConfig.load(), diff=diff, repo=None)
+    Pipeline(ctx, steps={"scoped": step}).run()
+
+    assert len(seen["diff"]) == 1
+    assert seen["diff"][0].path == "frontend/a.tsx"
+
+
+def test_pipeline_run_skips_scoped_step_with_no_matching_files(
+    monkeypatch, patch_github_action_env
+):
+    """If nothing in the diff falls under the step's scope, the step is skipped."""
+    mc.configure(LLM_API_TYPE=mc.ApiType.NONE)
+    patch_github_action_env(False)
+
+    class _F:
+        def __init__(self, path):
+            self.path = path
+
+    step = PipelineStep(call="x", envs=[PipelineEnv.LOCAL], scope="frontend")
+    step.run = MagicMock()
+
+    ctx = Context(
+        report=Report(),
+        config=ProjectConfig.load(),
+        diff=[_F("backend/only.py")],
+        repo=None,
+    )
+    Pipeline(ctx, steps={"scoped": step}).run()
+    step.run.assert_not_called()

--- a/tests/test_project_config.py
+++ b/tests/test_project_config.py
@@ -3,6 +3,7 @@ import textwrap
 from pathlib import Path
 
 from gito.project_config import ProjectConfig
+from gito.constants import PROJECT_CONFIG_FILE_PATH
 
 
 def test_load_defaults(monkeypatch):
@@ -39,3 +40,113 @@ def test_merge_pipeline_steps():
     assert "jira" in cfg.pipeline_steps
     assert cfg.pipeline_steps["linear"].enabled
     assert not cfg.pipeline_steps["jira"].enabled
+
+
+# --- Hierarchical (sub-directory) config tests --------------------------------
+
+
+def _write_config(dir_path: Path, body: str) -> Path:
+    gito_dir = dir_path / ".gito"
+    gito_dir.mkdir(parents=True, exist_ok=True)
+    path = gito_dir / "config.toml"
+    path.write_text(textwrap.dedent(body))
+    return path
+
+
+def test_hierarchical_lists_are_cumulative(tmp_path):
+    _write_config(tmp_path, """
+        exclude_files = ["root_only.txt"]
+        aux_files = ["root.md"]
+        mention_triggers = ["root-mention"]
+    """)
+    _write_config(tmp_path / "frontend", """
+        exclude_files = ["frontend_only.js"]
+        aux_files = ["frontend.md"]
+        mention_triggers = ["frontend-mention"]
+    """)
+    _write_config(tmp_path / "backend" / "svc", """
+        exclude_files = ["svc_only.go"]
+    """)
+
+    cfg = ProjectConfig.load(
+        config_path=tmp_path / PROJECT_CONFIG_FILE_PATH,
+        repo_root=tmp_path,
+    )
+    # Cumulative: every level contributes to the merged list.
+    for entry in ("root_only.txt", "frontend_only.js", "svc_only.go"):
+        assert entry in cfg.exclude_files, entry
+    assert "root.md" in cfg.aux_files and "frontend.md" in cfg.aux_files
+    assert "root-mention" in cfg.mention_triggers
+    assert "frontend-mention" in cfg.mention_triggers
+
+
+def test_hierarchical_scalar_root_supersedes(tmp_path):
+    _write_config(tmp_path, "retries = 9\n")
+    _write_config(tmp_path / "frontend", "retries = 99\nmax_code_tokens = 12345\n")
+
+    cfg = ProjectConfig.load(
+        config_path=tmp_path / PROJECT_CONFIG_FILE_PATH,
+        repo_root=tmp_path,
+    )
+    # Root wins on conflict; subdir-only scalar (max_code_tokens) still applies.
+    assert cfg.retries == 9
+    assert cfg.max_code_tokens == 12345
+
+
+def test_hierarchical_prompt_vars_root_wins_on_conflict(tmp_path):
+    _write_config(tmp_path, """
+        [prompt_vars]
+        shared = "from-root"
+        only_root = "yes"
+    """)
+    _write_config(tmp_path / "lib", """
+        [prompt_vars]
+        shared = "from-subdir"
+        only_subdir = "yep"
+    """)
+
+    cfg = ProjectConfig.load(
+        config_path=tmp_path / PROJECT_CONFIG_FILE_PATH,
+        repo_root=tmp_path,
+    )
+    assert cfg.prompt_vars["shared"] == "from-root"
+    assert cfg.prompt_vars["only_root"] == "yes"
+    assert cfg.prompt_vars["only_subdir"] == "yep"
+
+
+def test_hierarchical_pipeline_step_scope_and_root_wins(tmp_path):
+    _write_config(tmp_path, """
+        [pipeline_steps.jira]
+        enabled = false
+    """)
+    _write_config(tmp_path / "ui", """
+        [pipeline_steps.jira]
+        enabled = true
+        [pipeline_steps.ui_only_step]
+        call = "gito.pipeline_steps.linear.fetch_associated_issue"
+    """)
+
+    cfg = ProjectConfig.load(
+        config_path=tmp_path / PROJECT_CONFIG_FILE_PATH,
+        repo_root=tmp_path,
+    )
+    # Root's `enabled=false` for jira wins over subdir's `enabled=true`,
+    # but the `call` field is still inherited from the bundled defaults.
+    assert cfg.pipeline_steps["jira"].enabled is False
+    assert cfg.pipeline_steps["jira"].call
+    # Subdir-only step is registered and carries the subdir scope.
+    assert cfg.pipeline_steps["ui_only_step"].scope == "ui"
+    # Root-defined step has empty scope (repo-wide).
+    assert cfg.pipeline_steps["jira"].scope == ""
+
+
+def test_hierarchical_skips_ignored_dirs(tmp_path):
+    _write_config(tmp_path, "retries = 5\n")
+    # A config inside .venv should be ignored entirely.
+    _write_config(tmp_path / ".venv" / "pkg", "retries = 7777\n")
+
+    cfg = ProjectConfig.load(
+        config_path=tmp_path / PROJECT_CONFIG_FILE_PATH,
+        repo_root=tmp_path,
+    )
+    assert cfg.retries == 5


### PR DESCRIPTION
## Summary
  Adds hierarchical `.gito/config.toml` support: every `<subdir>/.gito/config.toml`
  under the repo root is discovered and merged with bundled defaults + the root
  project config.

  **Merge rules** (each level contributes only the keys it explicitly wrote):
  - Lists (`aux_files`, `exclude_files`, `mention_triggers`) — accumulate across
    all levels, deduped.
  - `prompt_vars` — union of keys; **root wins** on key conflict.
  - `pipeline_steps` — union of step names; **root wins** on name conflict.
    Per-step field-level merge is preserved (root setting `enabled=false` still
    inherits `call` from defaults).
  - Scalars (`prompt`, `retries`, `max_code_tokens`, …) — root supersedes;
    sub-directory configs only fill values the root left unset.

  **Pipeline step scoping:** steps defined inside a sub-directory carry a `scope`
  field equal to that directory; `Pipeline.run` filters `ctx.diff` to files under
  the scope and skips the step entirely when no diff files match. Steps defined
  in the root config keep `scope=""` and remain repo-wide.

  **Back-compat:** the existing single-file `ProjectConfig.load(config_path=...)`
  API is unchanged; if no `repo_root` is passed, discovery is skipped and
  behavior matches main.

  ## Test plan
  - 5 new tests in `tests/test_project_config.py`: cumulative lists, root-wins
    scalars, root-wins prompt_vars, pipeline step scope + per-field inheritance,
    ignored-dir pruning.
  - 3 new tests in `tests/test_pipeline.py`: `matches_path` boundaries, scoped
    diff filtering, scoped-step skip when no matching files.
  - All existing tests still pass: `pytest tests/test_project_config.py tests/test_pipeline.py` → 18
   passed locally.
  - Ran `gito review --against main` against this branch locally — **no issues found**.
