### PR TITLE
Add Support for uvx gito.bot

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ See [GitHub Setup Guide](https://github.com/Nayjest/Gito/blob/main/documentation
 - [Python](https://www.python.org/downloads/) 3.11 / 3.12 / 3.13  
 - [Git](https://git-scm.com)
 
-#### Option A: Install via pip (recommended)
+#### Option A: Install via pip
 
 **Step 1:** Install [gito.bot](https://github.com/Nayjest/Gito) using [pip](https://en.wikipedia.org/wiki/Pip_(package_manager)).
 ```bash
@@ -173,7 +173,21 @@ To install from repository source / specific branch:
 ```bash
 pip install git+https://github.com/Nayjest/Gito.git@<branch-or-tag>
 ```
-#### Option B: Windows Standalone Installer
+
+#### Option B: Run via `uvx` (no permanent install)
+
+Use [`uvx`](https://docs.astral.sh/uv/guides/tools/) when you want to run Gito without installing it globally:
+```bash
+uvx --from gito.bot gito setup
+uvx --from gito.bot gito review
+```
+
+> **Important:**  
+> Do not run `uvx gito review` unless you also pass `--from gito.bot`.  
+> The published package name is `gito.bot`, while the executable name is `gito`.  
+> Without `--from`, `uvx` will try to install an unrelated package named `gito` from PyPI.
+
+#### Option C: Windows Standalone Installer
 
 Download the latest Windows installer from [Releases](https://github.com/Nayjest/Gito/releases).
 

--- a/documentation/troubleshooting.md
+++ b/documentation/troubleshooting.md
@@ -62,6 +62,26 @@ MAX_CONCURRENT_TASKS=20
 
 For more details, refer to the [microcore configuration reference](https://ai-microcore.github.io/api-reference/microcore/configuration.html#Config.MAX_CONCURRENT_TASKS).
 
+## 3. `uvx gito ...` installs the wrong package
+
+If you run:
+```bash
+uvx gito review
+```
+
+`uvx` will try to install a package named `gito` from PyPI. Gito is published under the package name `gito.bot`, while its CLI executable is named `gito`.
+
+Use one of these commands instead:
+```bash
+uvx --from gito.bot gito setup
+uvx --from gito.bot gito review
+```
+
+You can also pin a specific version:
+```bash
+uvx --from "gito.bot==4.0.3" gito review
+```
+
 
 ## Getting Help
 

--- a/gito/bootstrap.py
+++ b/gito/bootstrap.py
@@ -1,9 +1,11 @@
 """Bootstrap module for initializing the Gito application environment."""
 
+import atexit
 import os
 import sys
 import io
 import logging
+import tempfile
 from datetime import datetime
 from pathlib import Path
 
@@ -13,6 +15,48 @@ from .utils.git_platform.gitlab import is_running_in_gitlab_ci
 from .utils.git_platform.github import is_running_in_github_action
 from .constants import HOME_ENV_PATH, EXECUTABLE, PROJECT_GITO_FOLDER, DEFAULT_MAX_CONCURRENT_TASKS
 from .env import Env
+
+
+def _is_empty_sentinel(value: str | None) -> bool:
+    """Return True when an env value is the string form of a missing value."""
+    if value is None:
+        return False
+    return value.strip().strip("\"'").lower() in {"none", "null"}
+
+
+def _sanitize_env_vars() -> None:
+    """Remove invalid shell env values that should behave like 'unset'."""
+    if _is_empty_sentinel(os.environ.get("LLM_API_PLATFORM")):
+        logging.warning("Ignoring invalid LLM_API_PLATFORM shell value.")
+        os.environ.pop("LLM_API_PLATFORM", None)
+
+
+def _sanitized_home_env_path(home_env_path: Path) -> Path:
+    """Return a temp env file path when persisted config contains invalid sentinels."""
+    if not home_env_path.exists():
+        return home_env_path
+
+    changed = False
+    sanitized_lines: list[str] = []
+    for line in home_env_path.read_text(encoding="utf-8").splitlines(keepends=True):
+        stripped = line.strip()
+        if stripped.startswith("LLM_API_PLATFORM="):
+            _, value = stripped.split("=", 1)
+            if _is_empty_sentinel(value):
+                changed = True
+                continue
+        sanitized_lines.append(line)
+
+    if not changed:
+        return home_env_path
+
+    logging.warning("Ignoring invalid LLM_API_PLATFORM value in %s.", home_env_path)
+    with tempfile.NamedTemporaryFile(
+        mode="w", encoding="utf-8", suffix=".env", prefix="gito-", delete=False
+    ) as temp_file:
+        temp_file.writelines(sanitized_lines)
+    atexit.register(lambda path=temp_file.name: os.path.exists(path) and os.unlink(path))
+    return Path(temp_file.name)
 
 
 def setup_logging(log_level: int = logging.INFO):
@@ -59,8 +103,9 @@ def bootstrap(verbosity: int = 1):
         sys.stdout = io.TextIOWrapper(sys.stdout.buffer, encoding="utf-8")
 
     try:
+        _sanitize_env_vars()
         mc.configure(
-            DOT_ENV_FILE=HOME_ENV_PATH,
+            DOT_ENV_FILE=_sanitized_home_env_path(HOME_ENV_PATH),
             USE_LOGGING=verbosity >= 1,
             EMBEDDING_DB_TYPE=mc.EmbeddingDbType.NONE,
             PROMPT_TEMPLATES_PATH=[PROJECT_GITO_FOLDER, Path(__file__).parent / "tpl"],

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -1,0 +1,44 @@
+import os
+from pathlib import Path
+
+from gito.bootstrap import _sanitize_env_vars, _sanitized_home_env_path
+
+
+def test_sanitized_home_env_path_drops_invalid_platform(tmp_path: Path):
+    env_file = tmp_path / ".env"
+    env_file.write_text(
+        "LLM_API_TYPE=openai\n"
+        "LLM_API_PLATFORM=None\n"
+        "MODEL=deepseek-v4-flash\n",
+        encoding="utf-8",
+    )
+
+    sanitized_path = _sanitized_home_env_path(env_file)
+
+    assert sanitized_path != env_file
+    assert sanitized_path.read_text(encoding="utf-8") == (
+        "LLM_API_TYPE=openai\n"
+        "MODEL=deepseek-v4-flash\n"
+    )
+
+
+def test_sanitized_home_env_path_keeps_valid_platform(tmp_path: Path):
+    env_file = tmp_path / ".env"
+    env_file.write_text(
+        "LLM_API_TYPE=openai\n"
+        "LLM_API_PLATFORM=azure\n"
+        "MODEL=gpt-5.2\n",
+        encoding="utf-8",
+    )
+
+    sanitized_path = _sanitized_home_env_path(env_file)
+
+    assert sanitized_path == env_file
+
+
+def test_sanitize_env_vars_removes_invalid_platform(monkeypatch):
+    monkeypatch.setenv("LLM_API_PLATFORM", "None")
+
+    _sanitize_env_vars()
+
+    assert "LLM_API_PLATFORM" not in os.environ

--- a/uv.lock
+++ b/uv.lock
@@ -1,0 +1,3 @@
+version = 1
+revision = 3
+requires-python = ">=3.13"


### PR DESCRIPTION
This pull request introduces improved handling of invalid environment variable values for `LLM_API_PLATFORM`, updates documentation to clarify installation via `uvx`, and adds tests for the new environment sanitization logic. The most important changes are as follows:

**Environment variable sanitization:**

* Added `_sanitize_env_vars` and `_sanitized_home_env_path` functions to `gito/bootstrap.py` to ignore or remove invalid sentinel values (such as `"none"` or `"null"`) for `LLM_API_PLATFORM` from both the shell environment and `.env` files. This prevents misconfiguration due to placeholder values. [[1]](diffhunk://#diff-a0656c48a68650ea85dc60c1314a137c86d6bd5a604200b5f9599923d1c85d2aR20-R61) [[2]](diffhunk://#diff-a0656c48a68650ea85dc60c1314a137c86d6bd5a604200b5f9599923d1c85d2aR106-R108)
* Updated the `bootstrap` function to use the sanitized environment variables and `.env` file path during application startup.

**Testing:**

* Added tests in `tests/test_bootstrap.py` to verify that invalid `LLM_API_PLATFORM` values are properly removed from both the environment and `.env` files, and that valid values are preserved.

**Documentation improvements:**

* Updated the installation instructions in `README.md` to clarify the use of `uvx` for running Gito without a global install, and explained the difference between the package name (`gito.bot`) and the CLI executable (`gito`).
* Added troubleshooting guidance in `documentation/troubleshooting.md` for users who might accidentally install the wrong package with `uvx`, including correct usage examples.