### PR TITLE
feat: include PR description and comments in review context

### DIFF
--- a/gito/config.toml
+++ b/gito/config.toml
@@ -144,6 +144,12 @@ Review the provided code diff carefully and identify *only* highly confident iss
 {{ input }}
 --------
 
+{% if pr_context -%}
+----PULL REQUEST CONTEXT----
+{{ pr_context }}
+--------
+{%- endif %}
+
 {% if file_lines -%}
 ----ADDITIONAL CONTEXT: FULL FILE CONTENT AFTER APPLYING REVIEWED CHANGES----
 {{ file_lines }}

--- a/gito/core.py
+++ b/gito/core.py
@@ -24,6 +24,7 @@ from .utils.cli import make_streaming_function
 from .pipeline import Pipeline
 from .env import Env
 from .gh_api import gh_api
+from .pr_context import _fetch_pr_context
 
 
 def review_subject_is_index(what):
@@ -503,6 +504,12 @@ async def review(
         """
         return not target.is_full_codebase_review() and not file_diff.is_added_file
 
+    pr_context = _fetch_pr_context(target, repo, cfg)
+
+    prompt_extra = cfg.prompt_vars.copy()
+    if pr_context:
+        prompt_extra["pr_context"] = pr_context
+
     responses = await mc.llm_parallel(
         [
             mc.prompt(
@@ -513,7 +520,7 @@ async def review(
                     else str(file_diff.path) + ":\n" + lines[file_diff.path]
                 ),
                 file_lines=lines[file_diff.path] if input_is_diff(file_diff) else None,
-                **cfg.prompt_vars,
+                **prompt_extra,
             )
             for file_diff in diff
         ],
@@ -613,6 +620,15 @@ def answer(
     else:
         aux_files_dict = {}
 
+    pr_context = _fetch_pr_context(
+        target=ReviewTarget(pull_request_id=str(pr) if pr else None),
+        repo=repo,
+        config=config,
+    )
+    prompt_vars = config.prompt_vars.copy()
+    if pr_context:
+        prompt_vars["pr_context"] = pr_context
+
     if not prompt_file and config.answer_prompt.startswith("tpl:"):
         prompt_file = str(config.answer_prompt)[4:]
 
@@ -626,7 +642,7 @@ def answer(
         all_file_lines=lines,
         pipeline_out=ctx.pipeline_out,
         aux_files=aux_files_dict,
-        **config.prompt_vars,
+        **prompt_vars,
     )
     response = mc.llm(
         prompt,

--- a/gito/pr_context.py
+++ b/gito/pr_context.py
@@ -1,0 +1,47 @@
+import logging
+
+from gito.gh_api import gh_api
+
+
+def _fetch_pr_context(target, repo, config) -> str:
+    """
+    Fetch PR description and comments to include as review context.
+    Returns empty string if not a PR review or if fetching fails.
+    """
+    if not target.pull_request_id:
+        return ""
+
+    if not getattr(config, "include_pr_context", True):
+        return ""
+
+    try:
+        api = gh_api(repo=repo)
+        pr_number = int(target.pull_request_id)
+
+        pr = api.pulls.get(pr_number)
+        pr_description = (pr.get("body") or "").strip()
+        pr_title = pr.get("title") or ""
+
+        comments_resp = api.issues.list_comments(pr_number)
+        comment_lines = []
+        for c in comments_resp:
+            body = (c.get("body") or "").strip()
+            if body:
+                user = c.get("user", {}).get("login", "unknown")
+                comment_lines.append(f"@{user}: {body}")
+
+        parts = []
+        if pr_title:
+            parts.append("PR Title: " + pr_title)
+        if pr_description:
+            parts.append("PR Description:\n" + pr_description)
+        if comment_lines:
+            parts.append("PR Comments:\n" + "\n".join(comment_lines))
+
+        return "\n\n".join(parts) if parts else ""
+
+    except Exception as e:
+        logging.warning(
+            "Failed to fetch PR context for #%s: %s", target.pull_request_id, e
+        )
+        return ""

--- a/gito/project_config.py
+++ b/gito/project_config.py
@@ -46,6 +46,11 @@ class ProjectConfig:
     If True, previously added code review comments in the pull request
     will be collapsed automatically when a new comment is added.
     """
+    include_pr_context: bool = field(default=True)
+    """
+    If True, the PR description and comments will be fetched and included
+    in the review prompt context. Set to False to save tokens.
+    """
 
     def __post_init__(self):
         self.pipeline_steps = {

--- a/tests/test_pr_context.py
+++ b/tests/test_pr_context.py
@@ -1,0 +1,81 @@
+from unittest.mock import MagicMock, patch
+
+from gito.pr_context import _fetch_pr_context
+from gito.report_struct import ReviewTarget
+from gito.project_config import ProjectConfig
+
+
+def test_fetch_pr_context_no_pr_id():
+    """Should return empty string when no pull_request_id is set."""
+    target = ReviewTarget(pull_request_id=None)
+    config = ProjectConfig()
+    result = _fetch_pr_context(target, MagicMock(), config)
+    assert result == ""
+
+
+def test_fetch_pr_context_disabled_by_config():
+    """Should return empty string when include_pr_context is False."""
+    target = ReviewTarget(pull_request_id="123")
+    config = ProjectConfig(include_pr_context=False)
+    result = _fetch_pr_context(target, MagicMock(), config)
+    assert result == ""
+
+
+def test_fetch_pr_context_success():
+    """Should return formatted PR context when API calls succeed."""
+    target = ReviewTarget(pull_request_id="42")
+    config = ProjectConfig(include_pr_context=True)
+
+    mock_pr = {
+        "title": "Fix login bug",
+        "body": "This PR fixes the login issue described in #100",
+    }
+    mock_comments = [
+        {"user": {"login": "alice"}, "body": "Looks good!"},
+        {"user": {"login": "bob"}, "body": "Please fix the typo"},
+    ]
+
+    mock_api = MagicMock()
+    mock_api.pulls.get.return_value = mock_pr
+    mock_api.issues.list_comments.return_value = mock_comments
+
+    mock_repo = MagicMock()
+
+    with patch("gito.pr_context.gh_api", return_value=mock_api):
+        result = _fetch_pr_context(target, mock_repo, config)
+
+    assert "PR Title: Fix login bug" in result
+    assert "PR Description:" in result
+    assert "This PR fixes the login issue" in result
+    assert "@alice: Looks good!" in result
+    assert "@bob: Please fix the typo" in result
+
+
+def test_fetch_pr_context_api_failure():
+    """Should return empty string when API call fails."""
+    target = ReviewTarget(pull_request_id="42")
+    config = ProjectConfig(include_pr_context=True)
+
+    with patch("gito.pr_context.gh_api", side_effect=Exception("API error")):
+        result = _fetch_pr_context(target, MagicMock(), config)
+
+    assert result == ""
+
+
+def test_fetch_pr_context_no_description():
+    """Should handle PR with no description body."""
+    target = ReviewTarget(pull_request_id="42")
+    config = ProjectConfig(include_pr_context=True)
+
+    mock_pr = {"title": "Update README", "body": ""}
+    mock_comments = []
+
+    mock_api = MagicMock()
+    mock_api.pulls.get.return_value = mock_pr
+    mock_api.issues.list_comments.return_value = mock_comments
+
+    with patch("gito.pr_context.gh_api", return_value=mock_api):
+        result = _fetch_pr_context(target, MagicMock(), config)
+
+    assert "PR Title: Update README" in result
+    assert "PR Description" not in result


### PR DESCRIPTION
Adds PR description and comments as context when reviewing pull requests.

**Changes:**
- `gito/pr_context.py` — fetches PR title, description, and issue comments via GitHub API
- `gito/core.py` — `review()` and `answer()` pass `pr_context` to the prompt when a PR ID is set
- `gito/config.toml` — prompt template includes a `----PULL REQUEST CONTEXT----` section that shows up when `pr_context` is available
- `gito/project_config.py` — added `include_pr_context` config option (default `true`) so users can disable this to save tokens
- `tests/test_pr_context.py` — 5 tests for the fetch logic

The PR context only gets fetched when `pull_request_id` is set on the review target (i.e. when triggered from a PR workflow or with `--pr`).

Closes #230