### PR TITLE
Upgrade ai-microcore to ~6.4.4, bump version to 4.3.0

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2,14 +2,14 @@
 
 [[package]]
 name = "ai-microcore"
-version = "6.4.1"
+version = "6.4.4"
 description = "# Minimalistic Foundation for AI Applications"
 optional = false
 python-versions = ">=3.10"
 groups = ["main"]
 files = [
-    {file = "ai_microcore-6.4.1-py3-none-any.whl", hash = "sha256:a069d2ec62ebe29e2a6e5635cd4d173c220324c99e52d9ee6f7d10c6ca6a83dd"},
-    {file = "ai_microcore-6.4.1.tar.gz", hash = "sha256:9dc9892f1e51990c7eb4f469356de0e5a5d63eb93f80ad170ee5a3b060133a2a"},
+    {file = "ai_microcore-6.4.4-py3-none-any.whl", hash = "sha256:8a280be56279afc3614b9bd612789b967360254099ee52602c94f09cc3b0c542"},
+    {file = "ai_microcore-6.4.4.tar.gz", hash = "sha256:0b619d4a3133164e5bd5917ecb029ff9f45c9e82b837e1108866b10c15b151e0"},
 ]
 
 [package.dependencies]
@@ -4468,4 +4468,4 @@ type = ["pytest-mypy (>=1.0.1) ; platform_python_implementation != \"PyPy\""]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.11"
-content-hash = "e0444551493fe5ef31435b6c7ad76d1f5e6e7a91b3bb3a0cfde5f27f6caa2aaa"
+content-hash = "33a18bffa10a3cd788a97b3cc9b54655383fe9cd7271b1927b02f2f5b29d3517"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "gito.bot"
-version = "4.2.1"
+version = "4.3.0"
 description = "AI code review tool that works with any language model provider. It detects issues in GitHub pull requests or local changes—instantly, reliably, and without vendor lock-in."
 readme = "README.md"
 license = "MIT"
@@ -63,7 +63,7 @@ packages = [
 "Bug Tracker" = "https://github.com/Nayjest/Gito/issues"
 [tool.poetry.dependencies]
 python = "^3.11"
-ai-microcore = "~6.4.1"
+ai-microcore = "~6.4.4"
 GitPython = "^3.1.50"
 unidiff = "^0.7.5"
 google-genai = "~2.10.0"


### PR DESCRIPTION
Upgrades ai-microcore dependency to ~6.4.4 and bumps package version to 4.3.0 for the next minor release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)