### PR TITLE
docs: commit AI-agent context (AGENTS.md/CLAUDE.md) and fix stale CLI reference

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,51 @@
+# AGENTS.md
+
+This file provides guidance to Codex (Codex.ai/code) when working with code in this repository.
+
+## What this is
+
+Gito (`gito.bot` on PyPI) is an open-source, vendor-agnostic AI code reviewer. It diffs git changes (local working copy, a branch, or a GitHub/GitLab PR/MR), sends each changed file to an LLM in parallel, and produces a structured report rendered to the CLI, Markdown (for PR comments), or GitLab Code Quality JSON. It can also answer free-form questions about a changeset and react to PR comments.
+
+The package is `gito/`; tests are in `tests/`. The CLI entrypoint is `gito.entrypoint:main` (commands `gito` and `gito.bot`).
+
+## Common commands
+
+```bash
+make install      # pip install -e . (dev: pip install -e ".[dev]")
+make test         # pytest --log-cli-level=INFO   (alias: make tests)
+pytest tests/test_core.py::test_name   # run a single test
+make black        # format (black ., line-length 100)
+make cs           # lint (flake8 ., max-line-length 100)
+make cli-reference  # regenerate documentation/command_line_reference.md (NOT on Windows — needs PYTHONUTF8)
+```
+
+This is a Poetry project (`pyproject.toml`), but the Makefile uses plain `pip`/`pytest`. Python 3.11–3.13. Tests use `pytest-asyncio`.
+
+Running the tool locally: `gito review` (current branch vs base), `gito ask "<question>"`, `gito files` (preview the changeset), `gito setup` (interactive LLM config wizard). Use `python -m gito` if the `gito` command isn't on PATH.
+
+## Architecture
+
+**LLM access is fully delegated to [ai-microcore](https://github.com/Nayjest/ai-microcore)** (imported as `microcore as mc`). Gito never talks to a provider SDK directly — `mc.llm()`, `mc.llm_parallel()`, `mc.prompt()`, `mc.tpl()`, and `mc.tokenizing` handle inference, templating (Jinja2), parallelism, retries, and JSON parsing. Provider/model/keys come from env vars (`LLM_API_TYPE`, `LLM_API_KEY`, `MODEL`, `MAX_CONCURRENT_TASKS`), loaded from `~/.gito/.env`. Adding a provider is a microcore concern, not a Gito one.
+
+**Two-layer configuration:**
+- *Environment* (`~/.gito/.env` or OS env) → LLM credentials/model. Machine-specific, never committed. See `gito/env.py`.
+- *Project* (`<repo>/.gito/config.toml`) → review behavior, prompts, templates, pipeline steps. Merged on top of the bundled defaults in **`gito/config.toml`**, which is the canonical source of all prompt text, report templates, tags, severity/confidence scales, and `post_process`/`prompt_vars`. `ProjectConfig` (`gito/project_config.py`) loads and merges these.
+
+**Review flow** (`gito/core.py`, the heart of the codebase):
+1. `get_diff` / `get_target_diff` build a `unidiff.PatchSet` from git. Most complexity lives in `get_base_branch` and the merge-base logic in `get_diff` — it resolves the comparison base across local branches, already-merged branches (walks merge commits to find the first common ancestor), GitHub Actions env, and full-codebase reviews (`--all` → `REFS_VALUE_ALL`). Binary files are filtered out; `filter_diff` applies fnmatch include/exclude filters.
+2. `review()` builds one prompt per changed file and runs them through `mc.llm_parallel(..., allow_failures=True)`. Per-file failures become `ProcessingWarning`s rather than aborting the run.
+3. LLM returns JSON validated against `RawIssue`; issues are post-processed by the user-supplied `post_process` Python snippet via `exec` (default keeps only confidence==1, severity<=3).
+4. Results assemble into a `Report` (`gito/report_struct.py`), which renders via the Jinja templates in config (`report_template_md`, `report_template_cli`, `report_template_gitlab_code_quality`). Outputs: `code-review-report.json` + `code-review-report.md`.
+
+**Pipeline steps** (`gito/pipeline.py`, `gito/pipeline_steps/`): configurable post-diff hooks declared in config under `[pipeline_steps.*]` as `call = "module.path.func"`, resolved dynamically via `resolve_callable`. Each runs gated by environment (`local` vs `ci`, see `PipelineEnv`), and its return dict is merged into `ctx.pipeline_out` for use in prompts (e.g. `pipeline_out.associated_issue`). This is how Jira/Linear issue-tracker context gets injected.
+
+**CLI** (`gito/cli.py` + `gito/cli_base.py`): Typer app. Commands are registered across `cli.py` and `gito/commands/` (the `from .commands import ...` line in `cli.py` exists to trigger registration). There's a dual-mode setup: `gito review ...` (subcommand) and a bare `gito` invocation (`app_no_subcommand`) handled in `entrypoint`/`main`. `bootstrap()` (`gito/bootstrap.py`) runs before commands to configure microcore, logging, verbosity, and UTF-8 stdout on Windows.
+
+**Git platform adapters** (`gito/utils/git_platform/`): GitHub (`ghapi`) and GitLab abstractions for identifying the platform, resolving repo URLs, and posting comments. `gito/gh_api.py`, `gito/gitlab.py`, `gito/issue_trackers.py` are the integration surfaces.
+
+## Conventions
+
+- `Context` (`gito/context.py`) is the dataclass passed through review/answer/pipeline carrying `repo`, `diff`, `config`, `report`, `pipeline_out`.
+- Prompt/template strings live in config TOML and `gito/tpl/*.j2`, not in Python. To change review behavior, edit `gito/config.toml` (or document how users override it via `.gito/config.toml`) rather than hardcoding in `core.py`.
+- `post_process` and prompts are executed/rendered with user-controlled strings by design — this is the extensibility model, not a bug.
+- Windows is a first-class target (standalone PyInstaller installer via `gito.spec` / `make windows-build`); keep encoding-sensitive code UTF-8 safe.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,7 @@
+# CLAUDE.md
+
+@AGENTS.md
+
+## Claude Code
+
+Shared project guidance lives in `AGENTS.md`; keep only Claude-specific instructions here.

--- a/documentation/command_line_reference.md
+++ b/documentation/command_line_reference.md
@@ -23,14 +23,18 @@ $ gito [OPTIONS] COMMAND [ARGS]...
 
 **Commands**:
 
-* `fix`: Fix an issue from the code review report...
+* `github-comment`: Leave a GitHub PR comment with the review.
+* `post-gitlab-comment`: Leaves a comment with the review on the...
+* `gitlab-comment`: Leave a GitLab MR comment with the review.
+* `linear-comment`: Post a comment with specified text to the...
+* `fix`: Fix issues from the code review report...
 * `react-to-comment`: Handles direct agent instructions from...
 * `repl`: Python REPL with core functionality loaded...
-* `init`
-* `deploy`: Create and configure Gito GitHub Actions...
+* `ci`: Deploy Gito to repository&#x27;s CI pipeline...
+* `connect`: Deploy Gito to repository&#x27;s CI pipeline...
+* `init`: Deploy Gito to repository&#x27;s CI pipeline...
+* `deploy`: Create and deploy Gito workflows to your...
 * `version`: Show Gito version.
-* `github-comment`: Leave a GitHub PR comment with the review.
-* `linear-comment`: Post a comment with specified text to the...
 * `run`
 * `review`: Perform a code review of the target...
 * `answer`
@@ -40,19 +44,109 @@ $ gito [OPTIONS] COMMAND [ARGS]...
 * `report`: Render and display code review report.
 * `files`: List files in the changeset.
 
-## `gito fix`
+## `gito github-comment`
 
-Fix an issue from the code review report (latest code review results will be used by default)
+Leave a GitHub PR comment with the review.
 
 **Usage**:
 
 ```console
-$ gito fix [OPTIONS] ISSUE_NUMBER
+$ gito github-comment [OPTIONS]
+```
+
+**Options**:
+
+* `--md-report-file TEXT`
+* `--pr INTEGER`
+* `--gh-repo TEXT`: owner/repo
+* `--token TEXT`: GitHub token (or set GITHUB_TOKEN env var)
+* `--help`: Show this message and exit.
+
+## `gito post-gitlab-comment`
+
+Leaves a comment with the review on the current GitLab merge request.
+
+With --inline, posts an overview comment first, then each issue as a separate
+inline comment anchored to the affected diff lines (published together as one review).
+
+Requires a Project Access Token with &#x27;api&#x27; scope.
+The default $CI_JOB_TOKEN does not have write access to merge requests.
+
+Examples:
+  ```bash
+  gito gitlab-comment --token $GITLAB_ACCESS_TOKEN --project-id $CI_PROJECT_ID --merge-request-iid $CI_MERGE_REQUEST_IID
+  ```
+
+**Usage**:
+
+```console
+$ gito post-gitlab-comment [OPTIONS]
+```
+
+**Options**:
+
+* `--md-report-file TEXT`: Path to the markdown review file. Gito&#x27;s standard report file will be used by default.
+* `--json-report-file TEXT`: Path to the JSON review report (used with --inline). Gito&#x27;s standard report file will be used by default.
+* `--project-id TEXT`: GitLab project ID (numeric) or URL-encoded path
+* `--merge-request-iid INTEGER`: Merge Request IID
+* `--token TEXT`: GitLab access token (or set GITLAB_ACCESS_TOKEN env var)
+* `--base-url TEXT`: GitLab base URL (default env GITLAB_BASE_URL or https://gitlab.com)
+* `--inline`: Post each issue as a separate inline comment on the MR diff (works on all GitLab tiers); the main comment then contains only the review overview.
+* `--help`: Show this message and exit.
+
+## `gito gitlab-comment`
+
+Leave a GitLab MR comment with the review.
+
+**Usage**:
+
+```console
+$ gito gitlab-comment [OPTIONS]
+```
+
+**Options**:
+
+* `--md-report-file TEXT`: Path to the markdown review file. Gito&#x27;s standard report file will be used by default.
+* `--json-report-file TEXT`: Path to the JSON review report (used with --inline). Gito&#x27;s standard report file will be used by default.
+* `--project-id TEXT`: GitLab project ID (numeric) or URL-encoded path
+* `--merge-request-iid INTEGER`: Merge Request IID
+* `--token TEXT`: GitLab access token (or set GITLAB_ACCESS_TOKEN env var)
+* `--base-url TEXT`: GitLab base URL (default env GITLAB_BASE_URL or https://gitlab.com)
+* `--inline`: Post each issue as a separate inline comment on the MR diff (works on all GitLab tiers); the main comment then contains only the review overview.
+* `--help`: Show this message and exit.
+
+## `gito linear-comment`
+
+Post a comment with specified text to the associated Linear issue.
+
+**Usage**:
+
+```console
+$ gito linear-comment [OPTIONS] [TEXT]
 ```
 
 **Arguments**:
 
-* `ISSUE_NUMBER`: Issue number to fix  [required]
+* `[TEXT]`: Comment text (supports Markdown). Use &#x27;-&#x27; to read from stdin.
+
+**Options**:
+
+* `-k, --issue-key TEXT`: Linear issue key (if not provided, will be resolved from the current repo branch)
+* `--help`: Show this message and exit.
+
+## `gito fix`
+
+Fix issues from the code review report (latest code review results will be used by default). If no issue number is provided, attempts to fix all fixable issues.
+
+**Usage**:
+
+```console
+$ gito fix [OPTIONS] [ISSUE_NUMBERS]...
+```
+
+**Arguments**:
+
+* `[ISSUE_NUMBERS]...`: Issue number(s) to fix (separated by space, fixes all if omitted)
 
 **Options**:
 
@@ -60,6 +154,7 @@ $ gito fix [OPTIONS] ISSUE_NUMBER
 * `-d, --dry-run`: Only print changes without applying them
 * `--commit / --no-commit`: Commit changes after applying them  [default: no-commit]
 * `--push / --no-push`: Push changes to the remote repository  [default: no-push]
+* `--src-path TEXT`: Base path to prepend to file paths in the report (if report paths are relative)
 * `--help`: Show this message and exit.
 
 ## `gito react-to-comment`
@@ -101,7 +196,49 @@ $ gito repl [OPTIONS]
 
 * `--help`: Show this message and exit.
 
+## `gito ci`
+
+Deploy Gito to repository&#x27;s CI pipeline for automatic code reviews.
+
+**Usage**:
+
+```console
+$ gito ci [OPTIONS]
+```
+
+**Options**:
+
+* `--api-type [openai|azure|anyscale|deep_infra|anthropic|google_vertex_ai|google_ai_studio|google|function|transformers|cli|none]`: LLM API type (interactive if omitted)
+* `--commit / --no-commit`: Commit and push changes
+* `--rewrite / --no-rewrite`: Overwrite existing configuration  [default: no-rewrite]
+* `--to-branch TEXT`: Branch name for new PR containing Gito CI workflows  [default: gito-ci]
+* `--token TEXT`: GitHub token (or set GITHUB_TOKEN env var)
+* `--model TEXT`: Language model to use (interactive if omitted; &quot;default&quot; selects the recommended model)
+* `--help`: Show this message and exit.
+
+## `gito connect`
+
+Deploy Gito to repository&#x27;s CI pipeline for automatic code reviews.
+
+**Usage**:
+
+```console
+$ gito connect [OPTIONS]
+```
+
+**Options**:
+
+* `--api-type [openai|azure|anyscale|deep_infra|anthropic|google_vertex_ai|google_ai_studio|google|function|transformers|cli|none]`: LLM API type (interactive if omitted)
+* `--commit / --no-commit`: Commit and push changes
+* `--rewrite / --no-rewrite`: Overwrite existing configuration  [default: no-rewrite]
+* `--to-branch TEXT`: Branch name for new PR containing Gito CI workflows  [default: gito-ci]
+* `--token TEXT`: GitHub token (or set GITHUB_TOKEN env var)
+* `--model TEXT`: Language model to use (interactive if omitted; &quot;default&quot; selects the recommended model)
+* `--help`: Show this message and exit.
+
 ## `gito init`
+
+Deploy Gito to repository&#x27;s CI pipeline for automatic code reviews.
 
 **Usage**:
 
@@ -111,17 +248,19 @@ $ gito init [OPTIONS]
 
 **Options**:
 
-* `--api-type [openai|azure|anyscale|deep_infra|anthropic|google_vertex_ai|google_ai_studio|function|transformers|none]`
-* `--commit / --no-commit`
-* `--rewrite / --no-rewrite`: [default: no-rewrite]
-* `--to-branch TEXT`: Branch name for the new PR containing the Gito workflows commit  [default: gito_deploy]
+* `--api-type [openai|azure|anyscale|deep_infra|anthropic|google_vertex_ai|google_ai_studio|google|function|transformers|cli|none]`: LLM API type (interactive if omitted)
+* `--commit / --no-commit`: Commit and push changes
+* `--rewrite / --no-rewrite`: Overwrite existing configuration  [default: no-rewrite]
+* `--to-branch TEXT`: Branch name for new PR containing Gito CI workflows  [default: gito-ci]
 * `--token TEXT`: GitHub token (or set GITHUB_TOKEN env var)
+* `--model TEXT`: Language model to use (interactive if omitted; &quot;default&quot; selects the recommended model)
 * `--help`: Show this message and exit.
 
 ## `gito deploy`
 
-Create and configure Gito GitHub Actions for current repository.
-aliases: init
+Create and deploy Gito workflows to your CI pipeline for automatic code reviews.
+Run this command from your repository root.
+aliases: init, connect, ci
 
 **Usage**:
 
@@ -131,11 +270,12 @@ $ gito deploy [OPTIONS]
 
 **Options**:
 
-* `--api-type [openai|azure|anyscale|deep_infra|anthropic|google_vertex_ai|google_ai_studio|function|transformers|none]`
-* `--commit / --no-commit`
-* `--rewrite / --no-rewrite`: [default: no-rewrite]
-* `--to-branch TEXT`: Branch name for the new PR containing the Gito workflows commit  [default: gito_deploy]
+* `--api-type [openai|azure|anyscale|deep_infra|anthropic|google_vertex_ai|google_ai_studio|google|function|transformers|cli|none]`: LLM API type (interactive if omitted)
+* `--commit / --no-commit`: Commit and push changes
+* `--rewrite / --no-rewrite`: Overwrite existing configuration  [default: no-rewrite]
+* `--to-branch TEXT`: Branch name for new PR containing Gito CI workflows  [default: gito-ci]
 * `--token TEXT`: GitHub token (or set GITHUB_TOKEN env var)
+* `--model TEXT`: Language model to use (interactive if omitted; &quot;default&quot; selects the recommended model)
 * `--help`: Show this message and exit.
 
 ## `gito version`
@@ -147,43 +287,6 @@ Show Gito version.
 ```console
 $ gito version [OPTIONS]
 ```
-
-**Options**:
-
-* `--help`: Show this message and exit.
-
-## `gito github-comment`
-
-Leave a GitHub PR comment with the review.
-
-**Usage**:
-
-```console
-$ gito github-comment [OPTIONS]
-```
-
-**Options**:
-
-* `--md-report-file TEXT`
-* `--pr INTEGER`
-* `--gh-repo TEXT`: owner/repo
-* `--token TEXT`: GitHub token (or set GITHUB_TOKEN env var)
-* `--help`: Show this message and exit.
-
-## `gito linear-comment`
-
-Post a comment with specified text to the associated Linear issue.
-
-**Usage**:
-
-```console
-$ gito linear-comment [OPTIONS] [TEXT] [REFS]
-```
-
-**Arguments**:
-
-* `[TEXT]`
-* `[REFS]`: Git refs to review, .. (e.g., &#x27;HEAD..HEAD~1&#x27;). If omitted, the current index (including added but not committed files) will be compared to the repository’s main branch.
 
 **Options**:
 
@@ -210,10 +313,10 @@ e.g. &#x27;src/**/*.py&#x27;, may be comma-separated
 * `--merge-base / --no-merge-base`: Use merge base for comparison  [default: merge-base]
 * `--url TEXT`: Git repository URL
 * `--path TEXT`: Git repository path
-* `--post-comment / --no-post-comment`: Post review comment to GitHub  [default: no-post-comment]
-* `--pr INTEGER`: GitHub Pull Request number to post the comment to
+* `--post-comment / --no-post-comment`: Post review comment to git platform (GitHub, GitLab, etc.)  [default: no-post-comment]
+* `--pr INTEGER`: GitHub Pull Request number or GitLab Merge Request ID to post the comment to
 (for local usage together with --post-comment,
-in the github actions PR is resolved from the environment)
+in the GitHub/GitLab actions PR/MR is resolved from the environment)
 * `-o, --out, --output TEXT`: Output folder for the code review report
 * `--all / --no-all`: Review whole codebase  [default: no-all]
 * `--help`: Show this message and exit.
@@ -241,10 +344,10 @@ e.g. &#x27;src/**/*.py&#x27;, may be comma-separated
 * `--merge-base / --no-merge-base`: Use merge base for comparison  [default: merge-base]
 * `--url TEXT`: Git repository URL
 * `--path TEXT`: Git repository path
-* `--post-comment / --no-post-comment`: Post review comment to GitHub  [default: no-post-comment]
-* `--pr INTEGER`: GitHub Pull Request number to post the comment to
+* `--post-comment / --no-post-comment`: Post review comment to git platform (GitHub, GitLab, etc.)  [default: no-post-comment]
+* `--pr INTEGER`: GitHub Pull Request number or GitLab Merge Request ID to post the comment to
 (for local usage together with --post-comment,
-in the github actions PR is resolved from the environment)
+in the GitHub/GitLab actions PR/MR is resolved from the environment)
 * `-o, --out, --output TEXT`: Output folder for the code review report
 * `--all / --no-all`: Review whole codebase  [default: no-all]
 * `--help`: Show this message and exit.
@@ -331,7 +434,7 @@ $ gito render [OPTIONS] [FORMAT]
 
 **Arguments**:
 
-* `[FORMAT]`: [default: cli]
+* `[FORMAT]`: Report format: md (Markdown), cli (terminal)  [default: cli]
 
 **Options**:
 
@@ -350,7 +453,7 @@ $ gito report [OPTIONS] [FORMAT]
 
 **Arguments**:
 
-* `[FORMAT]`: [default: cli]
+* `[FORMAT]`: Report format: md (Markdown), cli (terminal)  [default: cli]
 
 **Options**:
 
@@ -380,4 +483,5 @@ $ gito files [OPTIONS] [REFS]
 e.g. &#x27;src/**/*.py&#x27;, may be comma-separated
 * `--merge-base / --no-merge-base`: Use merge base for comparison  [default: merge-base]
 * `--diff / --no-diff`: Show diff content  [default: no-diff]
+* `--all / --no-all`: Review whole codebase  [default: no-all]
 * `--help`: Show this message and exit.

--- a/documentation/command_line_reference.md
+++ b/documentation/command_line_reference.md
@@ -74,7 +74,8 @@ The default $CI_JOB_TOKEN does not have write access to merge requests.
 
 Examples:
   ```bash
-  gito gitlab-comment --token $GITLAB_ACCESS_TOKEN --project-id $CI_PROJECT_ID --merge-request-iid $CI_MERGE_REQUEST_IID
+  gito gitlab-comment --token $GITLAB_ACCESS_TOKEN
+  --project-id $CI_PROJECT_ID --merge-request-iid $CI_MERGE_REQUEST_IID
   ```
 
 **Usage**:

--- a/gito/commands/gitlab_post_review_comment.py
+++ b/gito/commands/gitlab_post_review_comment.py
@@ -209,10 +209,7 @@ def post_gitlab_cr_comment(
 
     Examples:
       ```bash
-      gito gitlab-comment \
-        --token $GITLAB_ACCESS_TOKEN \
-        --project-id $CI_PROJECT_ID \
-        --merge-request-iid $CI_MERGE_REQUEST_IID
+      gito gitlab-comment --token $GITLAB_ACCESS_TOKEN --project-id $CI_PROJECT_ID --merge-request-iid $CI_MERGE_REQUEST_IID
       ```
     """
     token = require_gl_token(token)

--- a/gito/commands/gitlab_post_review_comment.py
+++ b/gito/commands/gitlab_post_review_comment.py
@@ -209,7 +209,8 @@ def post_gitlab_cr_comment(
 
     Examples:
       ```bash
-      gito gitlab-comment --token $GITLAB_ACCESS_TOKEN --project-id $CI_PROJECT_ID --merge-request-iid $CI_MERGE_REQUEST_IID
+      gito gitlab-comment --token $GITLAB_ACCESS_TOKEN
+      --project-id $CI_PROJECT_ID --merge-request-iid $CI_MERGE_REQUEST_IID
       ```
     """
     token = require_gl_token(token)


### PR DESCRIPTION
## Summary
- Commit canonical `AGENTS.md` (architecture, conventions, common commands) plus a thin `CLAUDE.md` pointer, giving AI coding agents (Claude Code, Codex) and new contributors a shared, accurate source of context instead of none at all.
- Regenerate `documentation/command_line_reference.md`, which had drifted from the CLI: it was missing the `gitlab-comment`/`post-gitlab-comment` commands entirely and had stale `--post-comment` help text ("Post review comment to GitHub" instead of "...to git platform (GitHub, GitLab, etc.)").
- Fix the docstring in `gito/commands/gitlab_post_review_comment.py` that caused its `Examples:` bash snippet to render as a garbled run-on line (multiple squished spaces) — confirmed both in the generated doc and in real `--help` output, caused by Typer's help renderer collapsing the backslash-continued multi-line example.

Closes #307 (points 1 and 2; a CI check to keep the CLI reference doc from drifting again is left as a follow-up, not in scope here).

## Test plan
- [x] `python -m gito post-gitlab-comment --help` renders the example cleanly (verified locally)
- [x] `make cli-reference` output reviewed line-by-line against `gito/cli.py`/`gito/commands/*.py` option definitions — matches
- [ ] CI (flake8/pytest) — will confirm once checks run
