### PR TITLE
fix: support token-only Jira authentication

### DIFF
--- a/documentation/jira_integration.md
+++ b/documentation/jira_integration.md
@@ -38,13 +38,18 @@ If an associated issue is found, Gito’s summary prompt includes a special sect
 Gito reads Jira credentials from environment variables (or passed explicitly to the pipeline step):
 
 - `JIRA_URL` — Base Jira URL, e.g. `https://your-domain.atlassian.net`
-- `JIRA_USER` / `JIRA_USERNAME` / `JIRA_EMAIL` — Username/email for Jira auth
+- `JIRA_USER` / `JIRA_USERNAME` / `JIRA_EMAIL` — Optional username/email for Jira basic auth
 - `JIRA_TOKEN` / `JIRA_API_TOKEN` / `JIRA_API_KEY` — Jira API token
 
 Resolution order (as implemented in `gito/pipeline_steps/jira.py`):
 
-- Username: `jira_username` arg → `JIRA_USERNAME` → `JIRA_USER` → `JIRA_EMAIL`
+- Username (optional): `jira_username` arg → `JIRA_USERNAME` → `JIRA_USER` → `JIRA_EMAIL`
 - Token: `jira_api_token` arg → `JIRA_API_TOKEN` → `JIRA_API_KEY` → `JIRA_TOKEN`
+
+Authentication is selected automatically:
+
+- With a username, Gito uses Jira basic authentication, preserving the existing Jira Cloud setup.
+- Without a username, Gito uses token authentication (`token_auth`), which supports Jira Server and Data Center personal access tokens.
 
 ### Branch naming convention
 Gito extracts the issue key using `gito.issue_trackers.extract_issue_key()`, which expects:
@@ -83,7 +88,7 @@ The pipeline step lives here:
 Key logic:
 
 - `resolve_issue_key(repo)` determines the current branch (supports GitHub Actions env) and extracts the issue key.
-- `fetch_issue(...)` uses `jira.JIRA(..., basic_auth=(username, api_token))` and loads `jira.issue(issue_key)`.
+- `fetch_issue(...)` uses `jira.JIRA(..., basic_auth=(username, api_token))` when a username is configured; otherwise it uses `jira.JIRA(..., token_auth=api_token)`. It then loads `jira.issue(issue_key)`.
 
 The returned value is normalized into:
 
@@ -132,13 +137,21 @@ env:
   JIRA_USER: ${{ secrets.JIRA_USER }}
 ```
 
-### Required GitHub Secrets
+For token-authenticated Jira Server or Data Center, omit `JIRA_USER`:
+
+```yaml
+env:
+  JIRA_TOKEN: ${{ secrets.JIRA_TOKEN }}
+  JIRA_URL: ${{ secrets.JIRA_URL }}
+```
+
+### GitHub Secrets
 Add these secrets under:
 
 **Settings → Secrets and variables → Actions → New repository secret**
 
 - `JIRA_URL`
-- `JIRA_USER`
+- `JIRA_USER` (optional; omit for token-authenticated Jira Server/Data Center)
 - `JIRA_TOKEN`
 
 ## Disabling Jira integration
@@ -166,6 +179,8 @@ Common causes:
 - Wrong `JIRA_URL` (must match your Jira base URL)
 - Token is invalid/expired
 - User lacks permission to read the issue/project
+
+For Jira Server or Data Center using a personal access token, do not set `JIRA_USER`, `JIRA_USERNAME`, or `JIRA_EMAIL`; Gito will use token authentication automatically.
 
 Check workflow logs; errors are surfaced from `jira.JIRAError` with status code + response text.
 

--- a/gito/pipeline_steps/jira.py
+++ b/gito/pipeline_steps/jira.py
@@ -8,20 +8,22 @@ from gito.issue_trackers import IssueTrackerIssue, resolve_issue_key
 
 
 def fetch_issue(
-    issue_key: str, jira_url: str, username: str, api_token: str
+    issue_key: str, jira_url: str, username: str | None, api_token: str
 ) -> IssueTrackerIssue | None:
     """
     Fetch a Jira issue by its key.
     Args:
         issue_key (str): The key of the Jira issue to fetch.
         jira_url (str): The base URL of the Jira instance.
-        username (str): The Jira username for authentication.
+        username (str | None): The Jira username for basic authentication. When omitted,
+            token authentication is used instead.
         api_token (str): The Jira API token for authentication.
     Returns:
         IssueTrackerIssue | None: The fetched issue or None if not found/error.
     """
     try:
-        jira = JIRA(jira_url, basic_auth=(username, api_token))
+        auth = {"basic_auth": (username, api_token)} if username else {"token_auth": api_token}
+        jira = JIRA(jira_url, **auth)
         issue = jira.issue(issue_key)
         return IssueTrackerIssue(
             title=issue.fields.summary,
@@ -57,7 +59,6 @@ def fetch_associated_issue(
     )
     try:
         assert jira_url, "JIRA_URL is not set"
-        assert jira_username, "JIRA_USERNAME is not set"
         assert jira_token, "JIRA_API_TOKEN is not set"
     except AssertionError as e:
         logging.error(f"Jira configuration error: {e}")

--- a/tests/test_jira_pipeline.py
+++ b/tests/test_jira_pipeline.py
@@ -1,0 +1,59 @@
+from unittest.mock import MagicMock, patch
+
+from gito.issue_trackers import IssueTrackerIssue
+from gito.pipeline_steps.jira import fetch_associated_issue, fetch_issue
+
+
+def make_jira_issue(summary="Issue summary", description="Issue description"):
+    issue = MagicMock()
+    issue.fields.summary = summary
+    issue.fields.description = description
+    return issue
+
+
+def test_fetch_issue_uses_basic_auth_when_username_is_provided():
+    jira_issue = make_jira_issue()
+    with patch("gito.pipeline_steps.jira.JIRA") as jira_client:
+        jira_client.return_value.issue.return_value = jira_issue
+
+        result = fetch_issue("PROJ-123", "https://jira.example.com", "user@example.com", "token")
+
+    jira_client.assert_called_once_with(
+        "https://jira.example.com", basic_auth=("user@example.com", "token")
+    )
+    assert result == IssueTrackerIssue(
+        title="Issue summary",
+        description="Issue description",
+        url="https://jira.example.com/browse/PROJ-123",
+    )
+
+
+def test_fetch_issue_uses_token_auth_when_username_is_omitted():
+    jira_issue = make_jira_issue(description=None)
+    with patch("gito.pipeline_steps.jira.JIRA") as jira_client:
+        jira_client.return_value.issue.return_value = jira_issue
+
+        result = fetch_issue("PROJ-123", "https://jira.example.com/", None, "token")
+
+    jira_client.assert_called_once_with("https://jira.example.com/", token_auth="token")
+    assert result == IssueTrackerIssue(
+        title="Issue summary",
+        description="",
+        url="https://jira.example.com/browse/PROJ-123",
+    )
+
+
+def test_fetch_associated_issue_allows_token_only_configuration(monkeypatch):
+    monkeypatch.setenv("JIRA_URL", "https://jira.example.com")
+    monkeypatch.setenv("JIRA_TOKEN", "token")
+    monkeypatch.delenv("JIRA_USERNAME", raising=False)
+    monkeypatch.delenv("JIRA_USER", raising=False)
+    monkeypatch.delenv("JIRA_EMAIL", raising=False)
+
+    with patch("gito.pipeline_steps.jira.resolve_issue_key", return_value="PROJ-123"), patch(
+        "gito.pipeline_steps.jira.fetch_issue", return_value=MagicMock()
+    ) as fetch:
+        result = fetch_associated_issue(MagicMock())
+
+    fetch.assert_called_once_with("PROJ-123", "https://jira.example.com", None, "token")
+    assert "associated_issue" in result


### PR DESCRIPTION
## Summary

- support Jira token authentication when no username is configured
- preserve existing basic-auth behavior for username-based Jira setups
- document Jira Server/Data Center token-only configuration and add coverage for both authentication modes

## Root cause

The Jira pipeline required a username and always initialized the Jira client with `basic_auth`, preventing self-hosted Jira instances that use personal access tokens from supplying token-only authentication.

## Validation

- `pytest tests/test_jira_pipeline.py` (3 passed)
- `black --check gito/pipeline_steps/jira.py tests/test_jira_pipeline.py`
- `flake8 --toml-config pyproject.toml gito/pipeline_steps/jira.py tests/test_jira_pipeline.py`

Full-suite execution reached 94 passing tests; remaining failures were caused by the local Windows test environment's temporary-directory permissions and interpreter resolution.