### PR TITLE
Update deploy OpenAI model options

### DIFF
--- a/gito/commands/deploy.py
+++ b/gito/commands/deploy.py
@@ -391,9 +391,9 @@ def _configure_llm(
             "claude-haiku-4-5": f"Claude Haiku 4.5 {ui.dim}(cheapest but less capable)",
         },
         ApiType.OPENAI: {
-            "gpt-5.5": f"GPT-5.5 {ui.dim} (recommended)",
-            "gpt-5.4": "GPT-5.4",
-            "gpt-5.4-mini": "GPT-5.4 Mini",
+            "gpt-5.6": f"GPT-5.6 {ui.dim}(recommended)",
+            "gpt-5.6-terra": f"GPT-5.6 Terra {ui.dim}(balanced)",
+            "gpt-5.6-luna": f"GPT-5.6 Luna {ui.dim}(cost-sensitive)",
         },
         ApiType.GOOGLE: {
             "gemini-2.5-pro": "Gemini 2.5 Pro",
@@ -423,7 +423,7 @@ def _configure_llm(
     }
     default_models = {
         ApiType.ANTHROPIC: "claude-sonnet-5",
-        ApiType.OPENAI: "gpt-5.5",
+        ApiType.OPENAI: "gpt-5.6",
         ApiType.GOOGLE: "gemini-2.5-pro",
     }
     use_default_model = model == "default"

--- a/tests/test_deploy.py
+++ b/tests/test_deploy.py
@@ -10,7 +10,7 @@ from typer.main import get_command
 
 import gito.cli  # noqa: F401  # registers CLI commands on the shared app
 from gito.cli_base import app, command_requires_llm
-from gito.commands.deploy import deploy
+from gito.commands.deploy import _configure_llm, deploy
 from gito.bootstrap import bootstrap
 from gito.utils.git_platform.platform_types import PlatformType
 
@@ -98,6 +98,15 @@ def test_bootstrap_ignores_llm_cli_for_non_llm_command(monkeypatch):
 
     assert mc.config().LLM_API_TYPE == mc.ApiType.NONE
     assert mc.config().LLM_CLI is None
+
+
+def test_deploy_uses_current_openai_default_model():
+    """`--model default` selects the current recommended OpenAI model."""
+    api_type, secret_name, model = _configure_llm("openai", model="default")
+
+    assert api_type == mc.ApiType.OPENAI
+    assert secret_name == "OPENAI_API_KEY"
+    assert model == "gpt-5.6"
 
 
 def test_deploy_github_creates_workflow_files(github_repo, monkeypatch):


### PR DESCRIPTION
## Summary

Closes #310.

- replace the deploy wizard's OpenAI choices with GPT-5.6, GPT-5.6 Terra, and GPT-5.6 Luna
- make `gpt-5.6` the `--model default` selection
- add regression coverage for the OpenAI default

## Validation

- `python -m py_compile gito/commands/deploy.py tests/test_deploy.py`
- `git diff --check`
- `pytest tests/test_deploy.py` could not run: the local test environment could not complete dependency installation because Windows repeatedly locked package files (`WinError 32`).