### PR TITLE
feat: add project config population command

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,6 +284,14 @@ Project settings follow a layered override model:
 
 Any values defined in your project's `.gito/config.toml` are merged on top of the built-in defaults. You only need to specify the settings you want to change—everything else falls back to sensible defaults.
 
+To create a complete, editable copy of the bundled defaults in the current repository, run:
+
+```bash
+gito populate-project-config
+```
+
+The command creates `.gito/config.toml` and refuses to replace an existing project configuration.
+
 #### Common Customizations
 
 - **Review prompts** — Tailor AI instructions, review criteria, and quality thresholds

--- a/documentation/command_line_reference.md
+++ b/documentation/command_line_reference.md
@@ -34,6 +34,7 @@ $ gito [OPTIONS] COMMAND [ARGS]...
 * `connect`: Deploy Gito to repository&#x27;s CI pipeline...
 * `init`: Deploy Gito to repository&#x27;s CI pipeline...
 * `deploy`: Create and deploy Gito workflows to your...
+* `populate-project-config`: Copy Gito&#x27;s bundled configuration to...
 * `version`: Show Gito version.
 * `run`
 * `review`: Perform a code review of the target...
@@ -277,6 +278,20 @@ $ gito deploy [OPTIONS]
 * `--to-branch TEXT`: Branch name for new PR containing Gito CI workflows  [default: gito-ci]
 * `--token TEXT`: GitHub token (or set GITHUB_TOKEN env var)
 * `--model TEXT`: Language model to use (interactive if omitted; &quot;default&quot; selects the recommended model)
+* `--help`: Show this message and exit.
+
+## `gito populate-project-config`
+
+Copy Gito&#x27;s bundled configuration to .gito/config.toml in the current repository.
+
+**Usage**:
+
+```console
+$ gito populate-project-config [OPTIONS]
+```
+
+**Options**:
+
 * `--help`: Show this message and exit.
 
 ## `gito version`

--- a/gito/cli.py
+++ b/gito/cli.py
@@ -42,7 +42,8 @@ from .commands.gitlab_post_review_comment import post_gitlab_cr_comment
 from .commands.linear_comment import linear_comment
 
 # Imported for registering commands
-from .commands import fix, gh_react_to_comment, repl, deploy, version  # noqa
+from .commands import fix, gh_react_to_comment, repl, deploy, version  # noqa: F401
+from .commands import populate_project_config  # noqa: F401
 
 app_no_subcommand = typer.Typer(pretty_exceptions_show_locals=False)
 

--- a/gito/commands/populate_project_config.py
+++ b/gito/commands/populate_project_config.py
@@ -1,0 +1,36 @@
+"""Create an editable project configuration from Gito's bundled defaults."""
+
+from pathlib import Path
+
+import microcore as mc
+import typer
+
+from ..cli_base import app, runs_without_llm
+from ..constants import PROJECT_CONFIG_BUNDLED_DEFAULTS_FILE, PROJECT_CONFIG_FILE_PATH
+from ..utils.git import get_cwd_repo_or_fail
+
+
+@app.command(
+    name="populate-project-config",
+    help="Copy Gito's bundled configuration to .gito/config.toml in the current repository.",
+)
+@runs_without_llm
+def populate_project_config() -> Path:
+    """Copy the bundled defaults into the current repository without overwriting a config."""
+    repo = get_cwd_repo_or_fail()
+    config_path = Path(repo.working_tree_dir) / PROJECT_CONFIG_FILE_PATH
+
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        bundled_config = PROJECT_CONFIG_BUNDLED_DEFAULTS_FILE.read_bytes()
+        with config_path.open("xb") as project_config:
+            project_config.write(bundled_config)
+    except FileExistsError as exc:
+        mc.ui.error(
+            f"Project configuration already exists at {mc.utils.file_link(config_path)}.\n"
+            "Remove or rename it before populating a fresh copy."
+        )
+        raise typer.Exit(code=1) from exc
+
+    print(mc.ui.green("Project configuration created:"), mc.utils.file_link(config_path))
+    return config_path

--- a/tests/test_deploy.py
+++ b/tests/test_deploy.py
@@ -20,6 +20,7 @@ from gito.utils.git_platform.platform_types import PlatformType
     [
         ("deploy", False),  # marked @runs_without_llm
         ("init", False),  # alias shares the marker
+        ("populate-project-config", False),
         ("version", False),  # another marked command
         ("review", True),  # performs inference
         ("repl", True),  # exposes live LLM access

--- a/tests/test_populate_project_config.py
+++ b/tests/test_populate_project_config.py
@@ -1,0 +1,49 @@
+"""Tests for populating a repository's project configuration."""
+
+from git import Repo
+from typer.testing import CliRunner
+
+import gito.cli  # noqa: F401  # registers CLI commands on the shared app
+from gito.cli_base import app
+from gito.constants import PROJECT_CONFIG_BUNDLED_DEFAULTS_FILE, PROJECT_CONFIG_FILE_PATH
+
+runner = CliRunner()
+
+
+def test_populate_project_config_copies_bundled_defaults(tmp_path, monkeypatch):
+    """The command creates an exact copy of the bundled configuration."""
+    Repo.init(tmp_path)
+    monkeypatch.chdir(tmp_path)
+
+    result = runner.invoke(app, ["populate-project-config"])
+
+    config_path = tmp_path / PROJECT_CONFIG_FILE_PATH
+    assert result.exit_code == 0
+    assert config_path.read_bytes() == PROJECT_CONFIG_BUNDLED_DEFAULTS_FILE.read_bytes()
+    assert "Project configuration created" in result.stdout
+
+
+def test_populate_project_config_does_not_overwrite_existing(tmp_path, monkeypatch):
+    """An existing project configuration is preserved."""
+    Repo.init(tmp_path)
+    monkeypatch.chdir(tmp_path)
+    config_path = tmp_path / PROJECT_CONFIG_FILE_PATH
+    config_path.parent.mkdir()
+    config_path.write_text("retries = 7\n", encoding="utf-8")
+
+    result = runner.invoke(app, ["populate-project-config"])
+
+    assert result.exit_code == 1
+    assert config_path.read_text(encoding="utf-8") == "retries = 7\n"
+    assert "Project configuration already exists" in result.stdout
+
+
+def test_populate_project_config_requires_repository(tmp_path, monkeypatch):
+    """The command does not write outside a repository root."""
+    monkeypatch.chdir(tmp_path)
+
+    result = runner.invoke(app, ["populate-project-config"])
+
+    assert result.exit_code == 2
+    assert not (tmp_path / PROJECT_CONFIG_FILE_PATH).exists()
+    assert "Current folder is not a Git repository" in result.stdout


### PR DESCRIPTION
## Summary

- add `gito populate-project-config` to copy the exact bundled defaults into `.gito/config.toml`
- create `.gito/` when needed while refusing to overwrite an existing file or symlink
- require a Git repository and run without LLM credentials
- document the command and add CLI/integration coverage

Addresses the first numbered request in #312.

## Testing

- `python -m pytest` — 115 passed, with one pre-existing deprecation warning
- CI-equivalent flake8 (`--exclude=.venv .`)
- Black check on the new command and tests
- pylint on `gito/commands/populate_project_config.py` — 10.00/10
- CLI reference regeneration
- `git diff --check`

## Limitations

- Loading a global configuration from `~/.gito`, the second numbered request in #312, is intentionally out of scope.
- Repository-wide pylint still reports pre-existing diagnostics; the new production module is clean.

Tooling disclosure: this change was prepared with OpenAI Codex and validated with the commands above.
