### PR TITLE
Fix: load configuration files starting with a UTF-8 BOM

### DIFF
--- a/gito/project_config.py
+++ b/gito/project_config.py
@@ -63,9 +63,9 @@ class ProjectConfig:
         Returns:
             dict: The default project configuration.
         """
-        with open(PROJECT_CONFIG_BUNDLED_DEFAULTS_FILE, "rb") as f:
-            config = tomllib.load(f)
-        return config
+        return tomllib.loads(
+            Path(PROJECT_CONFIG_BUNDLED_DEFAULTS_FILE).read_text(encoding="utf-8-sig")
+        )
 
     @staticmethod
     def load_for_repo(repo: Repo) -> "ProjectConfig":
@@ -100,8 +100,8 @@ class ProjectConfig:
             )
             default_prompt_vars = config["prompt_vars"]
             default_pipeline_steps = config["pipeline_steps"]
-            with open(config_path, "rb") as f:
-                config.update(tomllib.load(f))
+            # utf-8-sig strips the BOM written by PowerShell / Notepad on Windows
+            config.update(tomllib.loads(config_path.read_text(encoding="utf-8-sig")))
             # overriding prompt_vars config section will not empty default values
             config["prompt_vars"] = default_prompt_vars | config["prompt_vars"]
             # merge individual pipeline steps

--- a/gito/report_struct.py
+++ b/gito/report_struct.py
@@ -223,14 +223,14 @@ class Report:
     def save(self, file_name: str = ""):
         """Save the report to a JSON file."""
         file_name = file_name or JSON_REPORT_FILE_NAME
-        with open(file_name, "w") as f:
+        with open(file_name, "w", encoding="utf-8") as f:
             json.dump(asdict(self), f, indent=4)
         logging.info(f"Report saved to {mc.utils.file_link(file_name)}")
 
     @staticmethod
     def load(file_name: str | Path = ""):
         """Load the report from a JSON file."""
-        with open(file_name or JSON_REPORT_FILE_NAME, "r") as f:
+        with open(file_name or JSON_REPORT_FILE_NAME, "r", encoding="utf-8-sig") as f:
             data = json.load(f)
         data.pop("total_issues", None)
         return Report(**data)

--- a/tests/test_project_config.py
+++ b/tests/test_project_config.py
@@ -33,6 +33,21 @@ def test_prompt_vars_merging(tmp_path):
     assert cfg.retries == 7
 
 
+def test_load_config_with_utf8_bom(tmp_path):
+    sample = textwrap.dedent(
+        """
+    retries = 7
+    [prompt_vars]
+    foo = "bar"
+    """
+    )
+    toml_path = tmp_path / "config.toml"
+    toml_path.write_bytes(b"\xef\xbb\xbf" + sample.encode("utf-8"))
+    cfg = ProjectConfig.load(config_path=toml_path)
+    assert cfg.retries == 7
+    assert cfg.prompt_vars["foo"] == "bar"
+
+
 def test_merge_pipeline_steps():
     file = Path(__file__).parent / "fixtures" / "config-disable-jira.toml"
     cfg = ProjectConfig.load(config_path=file)

--- a/tests/test_report_struct.py
+++ b/tests/test_report_struct.py
@@ -136,6 +136,15 @@ def test_report_save_load(tmp_path):
     assert loaded_report.issues["file.py"][0].title == "Bug"
 
 
+def test_report_load_with_utf8_bom(tmp_path):
+    bootstrap()
+    file_name = tmp_path / "report.json"
+    Report(summary="SUMMARY").save(file_name)
+    file_name.write_bytes(b"\xef\xbb\xbf" + file_name.read_bytes())
+    loaded_report = Report.load(file_name)
+    assert loaded_report.summary == "SUMMARY"
+
+
 def get_issue_with_affected_lines():
     return {
         "id": "x",


### PR DESCRIPTION
Closes #315

## Problem

A `.gito/config.toml` starting with a UTF-8 byte order mark (`EF BB BF`) fails to load with `TOMLDecodeError: Invalid statement (at line 1, column 1)`, even though the file is valid TOML. PowerShell redirection, `Set-Content`, `Out-File` and Notepad all produce such files by default on Windows — a first-class target for Gito.

`Report.load()` is affected the same way: `json.load` on a BOM-prefixed report raises `JSONDecodeError: Unexpected UTF-8 BOM (decode using utf-8-sig)`.

## Fix

Read the TOML config and the JSON report with the `utf-8-sig` codec, which strips the BOM when present and is identical to `utf-8` when it is not.

- `gito/project_config.py` — `tomllib.load()` requires a binary file object and therefore cannot be given an encoding, so both config readers now read the text themselves and call `tomllib.loads()`.
- `gito/report_struct.py` — `Report.load()` opens with `encoding="utf-8-sig"`; `Report.save()` now writes with explicit `encoding="utf-8"` instead of the locale code page (which could break non-ASCII report content on Windows).

Same problem was fixed in lm-proxy: https://github.com/Nayjest/lm-proxy/pull/80

## Verification

New tests: `test_load_config_with_utf8_bom` (BOM-prefixed project config loads and merges normally) and `test_report_load_with_utf8_bom` (BOM-prefixed report JSON round-trips).

```
python -m pytest tests/ -q  ->  113 passed
```

`flake8` is clean on the touched files.
