### PR TITLE
fix(core): stop misclassifying deleted non-ASCII paths as binary

### DIFF
--- a/gito/core.py
+++ b/gito/core.py
@@ -158,9 +158,11 @@ def get_diff(
     logging.info(
         f"Making {comparison} diff: {ui.green(what or 'INDEX')} vs {ui.yellow(against)}"
     )
+    # Unquote non-ASCII paths (core.quotePath) so is_binary_file() gets real paths.
+    git = repo.git(c="core.quotePath=false")
     if use_merge_base:
         try:
-            comparison_base = repo.git.merge_base(against, what or "HEAD")
+            comparison_base = git.merge_base(against, what or "HEAD")
             closed_review_base = None
             if not review_subject_is_index(what) and comparison_base == repo.commit(what).hexsha:
                 closed_review_base = get_closed_review_base(repo, what, against)
@@ -170,13 +172,13 @@ def get_diff(
                     f"Reviewing merged ref {ui.green(what)} from its pre-merge base "
                     f"{ui.cyan(comparison_base[:8])}"
                 )
-                diff_content = repo.git.diff(comparison_base, what)
+                diff_content = git.diff(comparison_base, what)
             elif review_subject_is_index(what):
                 # With one commit, Git compares the working tree to the merge
                 # base of that commit and HEAD. This preserves local changes.
-                diff_content = repo.git.diff("--merge-base", against)
+                diff_content = git.diff("--merge-base", against)
             else:
-                diff_content = repo.git.diff("--merge-base", against, what)
+                diff_content = git.diff("--merge-base", against, what)
         except GitCommandError as e:
             raise MergeBaseError(
                 f"Cannot determine a merge base between '{against}' and '{what or 'HEAD'}'. "
@@ -184,7 +186,7 @@ def get_diff(
             ) from e
     else:
         comparison_base = against
-        diff_content = repo.git.diff(against, what)
+        diff_content = git.diff(against, what)
     diff = PatchSet.from_string(diff_content)
 
     # Filter out binary files

--- a/tests/test_diff.py
+++ b/tests/test_diff.py
@@ -1,3 +1,4 @@
+import logging
 from pathlib import Path
 
 import git
@@ -70,3 +71,17 @@ def test_merge_base_failure_does_not_fall_back_to_direct_diff(diverged_repo):
 
     with pytest.raises(MergeBaseError, match="Cannot determine a merge base"):
         get_diff(diverged_repo, what="feature", against="unrelated")
+
+
+def test_deleted_non_ascii_file_is_not_misclassified_as_binary(diverged_repo, caplog):
+    commit_file(diverged_repo, "файл.json", "{}", "Add non-ASCII file")
+
+    with caplog.at_level(logging.ERROR):
+        diff = get_diff(diverged_repo, what="feature", against="main", use_merge_base=False)
+
+    assert {patched_file.path for patched_file in diff} == {
+        "feature_only.txt",
+        "base_only.txt",
+        "файл.json",
+    }
+    assert not caplog.records


### PR DESCRIPTION
## Root cause

`git diff` C-quotes non-ASCII paths in its output unless `core.quotePath=false` is set
(the default is `true`). `unidiff` does not unquote them, so `get_diff()` was handing
`is_binary_file()` the raw quoted literal (e.g. `"a/\321\204..."`) instead of the real
path. That string resolves at neither the comparison ref's tree nor the working copy,
so the lookup falls through to the fallback branch, logs an ERROR, and the file gets
classified as binary and silently dropped from the diff, exactly as reported (a
deleted file logging "not found in the repository" and getting skipped as binary).

## Fix

Run every `git diff`/`git merge-base` call inside `get_diff()` through
`repo.git(c="core.quotePath=false")`, so `unidiff` always receives real, unescaped
paths. This is a general fix at the source of the bad path rather than a special case
for deleted files: it also protects the add/modify paths from the same quoting issue.

## Verification

- New regression test `test_deleted_non_ascii_file_is_not_misclassified_as_binary`
  (`tests/test_diff.py`): fails on `main` (misclassifies the file and logs the ERROR)
  and passes on this branch, run in a clean `python:3.12-slim` container both times.
- Full `pytest` suite: same 2 pre-existing failures in `tests/test_run.py` on both
  `main` and this branch (CLI invocation issue unrelated to this change), no new
  failures.
- `flake8 .` clean.
- Not verified: behavior under `core.quotePath` overridden to a non-default value by
  the caller's own global git config (this fix always forces it to `false` for the
  diff/merge-base calls it makes).

Fixes #188
