### PR TITLE
ci: run Code Style workflow on pull requests

### DIFF
--- a/.github/workflows/code-style.yml
+++ b/.github/workflows/code-style.yml
@@ -1,6 +1,6 @@
 name: Code Style
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   cs:


### PR DESCRIPTION
Closes #321

## Problem

`.github/workflows/code-style.yml` used `on: [push]`. Pull requests from forks generate no `push` event in this repository, so the `cs` (flake8) job never ran for external contributions.

This surfaced on #320, which introduced an unused-import violation with no `cs` check to catch it.

## Change

```diff
-on: [push]
+on: [push, pull_request]
```

Now matches `tests.yml`, which already runs on `pull_request`.

`coverage.yml` (push to `main`) and `windows-installer.yml` (release) are intentionally scoped and left unchanged.

## Note

Branch pushes still trigger `cs`, so pushing a branch and opening a PR from it within this repo will queue two runs — the same duplication `tests.yml` avoids by dropping `push`. Keeping `push` here preserves lint feedback on direct branch pushes; say the word and I'll narrow it to `pull_request` only.