### PR TITLE
ci: gate AI code review on fork PRs behind the external-pr environment

### DIFF
--- a/.github/workflows/gito-code-review.yml
+++ b/.github/workflows/gito-code-review.yml
@@ -10,6 +10,9 @@ on:
 jobs:
   review:
     runs-on: ubuntu-latest
+    # Fork PRs require maintainer approval before any fork code touches the secrets below.
+    # Same-repo PRs resolve to an empty environment name, which is a no-op, and run unattended.
+    environment: ${{ github.event.pull_request.head.repo.full_name != github.repository && 'external-pr' || '' }}
     permissions: { contents: read, pull-requests: write } # 'write' for leaving the summary comment
     steps:
     - uses: actions/checkout@v7
@@ -17,11 +20,16 @@ jobs:
         fetch-depth: 0
         # Checkout PR head to process actual changes (including forks).
         #
-        # ⚠️ SECURITY: This exposes secrets to fork code. Mitigate by:
-        #   1. Requiring approval for running fork pull request workflows from all external contributors
-        #      (Settings → Actions → General → Approval for running fork pull request workflows from contributors)
-        #   2. Reviewing PRs for secret exfiltration and other malicious code before approving workflow runs.
+        # ⚠️ SECURITY: This exposes secrets to fork code. Mitigated by the 'external-pr'
+        # environment on this job, which requires maintainer approval before the job starts.
+        #
+        # Note: the "Approval for running fork pull request workflows" setting
+        # (Settings → Actions → General) does NOT gate 'pull_request_target' — it only applies
+        # to 'pull_request'. The environment is what actually holds the run.
+        #
+        # Review PRs for secret exfiltration and other malicious code before approving.
         ref: ${{ github.event.pull_request.head.sha }}
+        allow-unsafe-pr-checkout: true
 
     - name: Set up Python
       uses: actions/setup-python@v6


### PR DESCRIPTION
Closes #323

## Problem

`Gito: AI Code Reviewer` fails on every fork PR (see #320):

```
##[error]Refusing to check out fork pull request code from a 'pull_request_target' workflow.
```

`actions/checkout@v7` (bumped in 932df9b) now requires an explicit opt-in for this. But the opt-in is only safe with a real approval gate — and the one the old comment referenced, *Settings → Actions → Approval for running fork pull request workflows*, **does not apply to `pull_request_target`**. It only holds `pull_request` runs. On #320 the `Tests` run sat in `action_required` while the review run started immediately.

Environment protection rules *do* hold `pull_request_target` jobs, and this repo already has `external-pr` (required reviewer: `Nayjest`). `gito-code-review.yml` just never referenced it.

## Change

```yaml
 review:
   runs-on: ubuntu-latest
+  environment: ${{ github.event.pull_request.head.repo.full_name != github.repository && 'external-pr' || '' }}
```
```yaml
       ref: ${{ github.event.pull_request.head.sha }}
+      allow-unsafe-pr-checkout: true
```

Plus a corrected security comment — the old one named a mitigation that does not apply to this trigger.

Mirrors the pattern already in `gito-react-to-comments.yml:56`.

## Behaviour

| PR source | Environment | Result |
|---|---|---|
| Same repo | `''` (no-op) | runs unattended, as today |
| Fork | `external-pr` | waits for maintainer approval, then runs |

`prevent_self_review` is `false` on `external-pr`, so you can approve your own runs.

## Verification

- Empty environment name confirmed a no-op on this repo: probe job ran in 6s with no approval prompt and no `''` environment created ([run 31520478685](https://github.com/Nayjest/Gito/actions/runs/31520478685), branch since deleted).
- Expression kept on one line deliberately: as a folded `>-` scalar the more-indented continuation retains a literal newline.

## Not verified

The end-to-end fork path — approval gate holds, then review completes — can only be proven by a real fork PR. **#320 is the natural test case: merge this, then re-run the review job there.**

## Known pre-existing limitation (unchanged here)

`workflow_dispatch` has no `pull_request` payload, so the environment resolves to `''` and dispatch stays unattended. That is consistent with dispatch already requiring write access — but note the checkout `ref` is likewise empty on dispatch, so it checks out the default branch rather than the requested PR. Pre-existing, out of scope.

## Follow-up

`fork-pr` and `external-pr` are duplicate environments with identical rules; only `external-pr` is referenced now. Worth deleting `fork-pr`.