### PR TITLE
fix(build): stamp VersionInfoVersion on the Windows installer

### DIFF
--- a/installer.iss
+++ b/installer.iss
@@ -14,6 +14,9 @@
 AppId={{B8E3F2A1-5C7D-4E9F-A2B1-3D6E8F0C9A4B}}
 AppName={#MyAppName}
 AppVersion={#MyAppVersion}
+; Stamps the setup binary's own file/product version resource, so the version is
+; visible in the .exe properties dialog and to installer inventory tooling.
+VersionInfoVersion={#MyAppVersion}
 AppPublisher={#MyAppPublisher}
 AppPublisherURL={#MyAppURL}
 AppSupportURL={#MyAppURL}


### PR DESCRIPTION
The setup `.exe` had a blank `FileVersion` — `installer.iss` set `AppVersion` and `OutputBaseFilename` from `{#MyAppVersion}` but never `VersionInfoVersion`, so the binary's own version resource was empty.

Verified against the 4.4.3 installer built from main (run 31633677661): `ProductVersion` = 4.4.3, `FileVersion` = empty. This makes them agree.

Follow-up to #331, before tagging v4.4.3.